### PR TITLE
Adds natty as a project dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ allprojects {
         compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
         compile "com.google.guava:guava:$guavaVersion"
+        compile "com.joestelmach:natty:0.12"
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.testfx:testfx-core:$testFxVersion"


### PR DESCRIPTION
Natty is a date parser library that allows natural date parsing into standard date formats that Java understands. Thus values such as "st/today 6pm et/tomorrow 1 pm" is possible.

This library is approved by for use by Prof (see IVLE forum).

Resolves #28 
@tanboonjoon