### PR TITLE
Starting date and Ending date now accepts natural date inputs

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -1,0 +1,22 @@
+package seedu.address.commons.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import com.joestelmach.natty.DateGroup;
+import com.joestelmach.natty.Parser;
+
+public final class DateUtil {
+	
+	public static LocalDateTime parseStringIntoDateTime (String rawString) {
+		Parser dateParser = new Parser() ;
+		
+		List<DateGroup> dates = dateParser.parse(rawString) ;
+		Date date = dates.get(0).getDates().get(0) ;
+		
+		return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()) ;
+	}
+	
+}

--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -2,6 +2,7 @@ package seedu.address.commons.util;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 
@@ -10,6 +11,8 @@ import com.joestelmach.natty.Parser;
 
 public final class DateUtil {
 	
+	public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy hh:mm a");
+	
 	public static LocalDateTime parseStringIntoDateTime (String rawString) {
 		Parser dateParser = new Parser() ;
 		
@@ -17,6 +20,10 @@ public final class DateUtil {
 		Date date = dates.get(0).getDates().get(0) ;
 		
 		return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()) ;
+	}
+	
+	public static String parseLocalDateTimeIntoString (LocalDateTime datetime) {
+		return datetime.format(FORMATTER) ;
 	}
 	
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 import seedu.address.model.task.Deadline;
@@ -30,8 +31,8 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the address book";
     public static final String INVALID_TASK_TYPE_MESSAGE = "Please add a endDate as well OR remove startDate from your command";
+    
     private Task toAdd;
-    private DateTimeFormatter formatter;
 
     /**
      * Convenience constructor using raw values.
@@ -40,8 +41,7 @@ public class AddCommand extends Command {
      */
     public AddCommand(String name, String description,String startDate,String endDate, Set<String> tags) throws IllegalValueException {
         final Set<Tag> tagSet = Sets.newHashSet() ;
-        formatter = DateTimeFormatter.ofPattern("ddMMyyy HHmm");
-        
+
         for (String tagName : tags) {
             tagSet.add(new Tag(tagName));
         }
@@ -50,25 +50,21 @@ public class AddCommand extends Command {
 
         	this.toAdd = new Task(name, description, new UniqueTagList(tagSet));
         	
-        }else if (startDate == null && endDate != null) {
+        } else if (startDate == null && endDate != null) {
         	
-        	LocalDateTime deadline_endDate = LocalDateTime.parse(endDate, formatter);
+        	LocalDateTime deadline_endDate = DateUtil.parseStringIntoDateTime(endDate) ;
         	this.toAdd = new Deadline(name, description, deadline_endDate, new UniqueTagList(tagSet));
         	
-        }else if (startDate !=null && endDate != null) {
+        } else if (startDate !=null && endDate != null) {
         	
-        	LocalDateTime event_startDate = LocalDateTime.parse(startDate, formatter);
-        	LocalDateTime event_endDate = LocalDateTime.parse(endDate, formatter);
+        	LocalDateTime event_startDate = DateUtil.parseStringIntoDateTime(startDate) ;
+        	LocalDateTime event_endDate = DateUtil.parseStringIntoDateTime(endDate) ;
+        	
         	this.toAdd = new Event(name, description, event_startDate, event_endDate, new UniqueTagList(tagSet));
         	
-        }else{
+        } else {
         	throw new IllegalValueException(INVALID_TASK_TYPE_MESSAGE);
         }
-        
-        
-        
-        
-        
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -2,6 +2,7 @@ package seedu.address.model.task;
 
 import java.time.LocalDateTime;
 
+import seedu.address.commons.util.DateUtil;
 import seedu.address.model.tag.UniqueTagList;
 /**
 * A deadline is a task that has only a ending datetime
@@ -26,4 +27,19 @@ public class Deadline extends Task {
 				&& other instanceof Deadline
 				&& this.getEndDate().equals( ((Deadline) other).getEndDate() ) ;
 	}
+	
+	@Override
+	public String getAsText() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append(" Task Name: ")
+                .append(getName())
+                .append(" Description: ")
+                .append(getDescription())
+                .append(" Due by: ")
+                .append(DateUtil.parseLocalDateTimeIntoString(getEndDate()) )
+                .append(" Tags: ");
+        getTags().forEach(builder::append);
+        return builder.toString();
+    }
 }

--- a/src/main/java/seedu/address/model/task/Event.java
+++ b/src/main/java/seedu/address/model/task/Event.java
@@ -2,6 +2,7 @@ package seedu.address.model.task;
 
 import java.time.LocalDateTime;
 
+import seedu.address.commons.util.DateUtil;
 import seedu.address.model.tag.UniqueTagList;
 /**
 * A event is a task that has a start datetime and and a end datetime
@@ -33,5 +34,22 @@ public class Event extends Task {
 				&& this.getStartDate().equals( ((Event) other).getStartDate() )
 				&& this.getEndDate().equals( ((Event) other).getStartDate() ) ;
 	}
+	
+	@Override
+	public String getAsText() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append(" Task Name: ")
+                .append(getName())
+                .append(" Description: ")
+                .append(getDescription())
+                .append(" From: ")
+                .append(DateUtil.parseLocalDateTimeIntoString(getStartDate()) )
+                .append(" To: ")
+                .append(DateUtil.parseLocalDateTimeIntoString(getEndDate()) )
+                .append(" Tags: ");
+        getTags().forEach(builder::append);
+        return builder.toString();
+    }
 	
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.EventsCenter;
 import seedu.address.logic.commands.*;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
+import seedu.address.commons.util.DateUtil;
 import seedu.address.commons.events.model.TaskForceChangedEvent;
 import seedu.address.model.TaskForce;
 import seedu.address.model.Model;
@@ -190,7 +191,6 @@ public class LogicManagerTest {
                 expectedAB.getTaskList());
         
 
-        
         // Order does not matter 
         Task john = helper.john() ;
         expectedAB.addTask(john);
@@ -216,11 +216,10 @@ public class LogicManagerTest {
         Task test_deadline = helper.test_deadline();
         expectedAB.addTask(test_deadline);
 
-        
         CommandResult result = logic.execute("add event d/this is a event st/13022016 1300 et/13022016 1300");
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, test_event), result.feedbackToUser);
 
-        CommandResult result2 = logic.execute("add deadline d/this is a deadline et/13022016 1300");
+        CommandResult result2 = logic.execute("add deadline d/this is a deadline et/Aug 13 2016 1600");
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, test_deadline), result2.feedbackToUser);
 
 
@@ -440,13 +439,12 @@ public class LogicManagerTest {
         
 
         Task test_deadline() throws Exception {
-        	LocalDateTime endDate = LocalDateTime.parse("13022016 1300",  DateTimeFormatter.ofPattern("ddMMyyy HHmm"));
-        	return new Deadline("deadline", "this is a deadline", endDate, new UniqueTagList() );
+        	return new Deadline("deadline", "this is a deadline", DateUtil.parseStringIntoDateTime("13 Aug 16 1300"), new UniqueTagList() );
         }
         
         Task test_event() throws Exception {
-        	LocalDateTime startDate = LocalDateTime.parse("13022016 1300",  DateTimeFormatter.ofPattern("ddMMyyy HHmm"));
-        	LocalDateTime endDate = LocalDateTime.parse("13022016 1300",  DateTimeFormatter.ofPattern("ddMMyyy HHmm"));
+        	LocalDateTime startDate = DateUtil.parseStringIntoDateTime("13022016 1300") ;
+        	LocalDateTime endDate = DateUtil.parseStringIntoDateTime("13022016 1300");
         	return new Event("event", "this is a event", startDate, endDate, new UniqueTagList() );
 
         }


### PR DESCRIPTION
Thanks to the inclusion of the Natty date parser, the `st/` and `et/` flags now accept natural dates inputs from the user instead of the current rigid date format.

For example it will accept `st/today 6pm`, among others

Resolves #37 