### PR TITLE
Modify storage to save start and end dates.

### DIFF
--- a/src/main/java/seedu/address/model/TaskForce.java
+++ b/src/main/java/seedu/address/model/TaskForce.java
@@ -1,14 +1,26 @@
 package seedu.address.model;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
-import seedu.address.model.task.Task;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Event;
 import seedu.address.model.task.ReadOnlyTask;
+import seedu.address.model.task.Task;
 import seedu.address.model.task.UniqueTaskList;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Wraps all data at the address-book level
@@ -59,8 +71,32 @@ public class TaskForce implements ReadOnlyTaskForce {
     }
 
     public void resetData(Collection<? extends ReadOnlyTask> newTasks, Collection<Tag> newTags) {
-        setTasks(newTasks.stream().map(Task::new).collect(Collectors.toList()));
-        setTags(newTags);
+
+        List<Task> tasks = Lists.newLinkedList() ;
+        
+        for (ReadOnlyTask thisTask : newTasks) {
+            String name = thisTask.getName() ;
+            String description = thisTask.getDescription() ;
+            UniqueTagList tags = thisTask.getTags() ;
+            
+            if (thisTask instanceof Deadline) {
+                LocalDateTime end = ((Deadline) thisTask).getEndDate() ;
+                
+                tasks.add(new Deadline (name, description, end, tags)) ;
+            
+            } else if (thisTask instanceof Event) {
+                LocalDateTime start = ((Event) thisTask).getStartDate() ;
+                LocalDateTime end = ((Event) thisTask).getEndDate() ;
+                
+                tasks.add(new Event (name, description, start, end, tags)) ;
+            
+            } else {
+                tasks.add(new Task (name, description, tags)) ;
+            }
+        }
+        
+        setTasks (tasks) ;
+        setTags (newTags);
     }
 
     public void resetData(ReadOnlyTaskForce newData) {

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -6,6 +6,8 @@ import seedu.address.model.tag.UniqueTagList;
 import seedu.address.model.task.*;
 
 import javax.xml.bind.annotation.XmlElement;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +20,10 @@ public class XmlAdaptedTask {
     private String name;
     @XmlElement(required = true)
     private String description;
+    @XmlElement
+    private String startDateTime;
+    @XmlElement
+    private String endDateTime;
 
     @XmlElement
     private List<XmlAdaptedTag> tagged = new ArrayList<>();
@@ -37,8 +43,18 @@ public class XmlAdaptedTask {
         name = source.getName();
         description = source.getDescription() ;
         tagged = new ArrayList<>();
+        
         for (Tag tag : source.getTags()) {
             tagged.add(new XmlAdaptedTag(tag));
+        }
+        
+        if (source instanceof Deadline) {
+            endDateTime = ((Deadline) source).getEndDate().toString() ;
+        }
+        
+        if (source instanceof Event ) {
+            startDateTime = ((Event) source).getStartDate().toString() ;
+            endDateTime = ((Event) source).getEndDate().toString() ;
         }
     }
 
@@ -48,6 +64,10 @@ public class XmlAdaptedTask {
      * @throws IllegalValueException if there were any data constraints violated in the adapted task
      */
     public Task toModelType() throws IllegalValueException {
+        Task task ;
+        LocalDateTime start = null ;
+        LocalDateTime end = null ;
+        
         final List<Tag> taskTags = new ArrayList<>();
         for (XmlAdaptedTag tag : tagged) {
             taskTags.add(tag.toModelType());
@@ -56,6 +76,25 @@ public class XmlAdaptedTask {
         final String name = this.name ;
         final String description = this.description ;
         final UniqueTagList tags = new UniqueTagList(taskTags);
-        return new Task(name, description, tags);
+        
+        if (this.startDateTime != null) {
+            start = LocalDateTime.parse(this.startDateTime) ;
+        }
+        
+        if (this.endDateTime != null) {
+            end = LocalDateTime.parse(this.endDateTime) ;
+        }
+        
+        if (start != null && end != null) {
+            task = new Event (name, description, start, end, tags) ; 
+        
+        } else if (start == null && end != null) {
+            task = new Deadline (name, description, end, tags) ;
+        
+        } else {
+            task = new Task(name, description, tags);
+        }
+        
+        return task ;
     }
 }

--- a/src/test/java/seedu/address/storage/XmlTaskForceStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlTaskForceStorageTest.java
@@ -1,21 +1,25 @@
 package seedu.address.storage;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.FileUtil;
-import seedu.address.model.TaskForce;
-import seedu.address.model.task.Task;
 import seedu.address.model.ReadOnlyTaskForce;
+import seedu.address.model.TaskForce;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Event;
+import seedu.address.model.task.Task;
 import seedu.address.testutil.TypicalTestTasks;
-
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class XmlTaskForceStorageTest {
     private static String TEST_DATA_FOLDER = FileUtil.getPath("./src/test/data/XmlTaskForceStorageTest/");
@@ -73,6 +77,17 @@ public class XmlTaskForceStorageTest {
         //Modify data, overwrite exiting file, and read back
         original.addTask(new Task(TypicalTestTasks.hoon));
         original.removeTask(new Task(TypicalTestTasks.alice));
+        xmlTaskForceStorage.saveTaskForce(original, filePath);
+        readBack = xmlTaskForceStorage.readTaskForce(filePath).get();
+        assertEquals(original, new TaskForce(readBack));
+        
+        //Modify data, overwrite exiting file, and read back
+        original.addTask(new Deadline(TypicalTestTasks.hoon.getName(),TypicalTestTasks.hoon.getDescription(), LocalDateTime.now(), TypicalTestTasks.hoon.getTags()));
+        xmlTaskForceStorage.saveTaskForce(original, filePath);
+        readBack = xmlTaskForceStorage.readTaskForce(filePath).get();
+        assertEquals(original, new TaskForce(readBack));
+        
+        original.addTask(new Event(TypicalTestTasks.hoon.getName(),TypicalTestTasks.hoon.getDescription(), LocalDateTime.now(), LocalDateTime.now(), TypicalTestTasks.hoon.getTags()));
         xmlTaskForceStorage.saveTaskForce(original, filePath);
         readBack = xmlTaskForceStorage.readTaskForce(filePath).get();
         assertEquals(original, new TaskForce(readBack));


### PR DESCRIPTION
@tanboonjoon 

This PR will resolve a bug in #42. Closes #44.

The bug is due to the TaskForce system not saving the start and end dates into the XML file and once exited, the data is lost. Furthermore, upon re-opening of the application, the storage API repopulates all data as a Task object, causing all instanceof checks to fail miserably.