### PR TITLE
Users can now add/remove tags of existing task via the edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -103,12 +103,7 @@ public class EditCommand extends Command {
             newDescription = taskToEdit.getDescription();
         }
         
-        if(!tagSet.isEmpty()) {
-            newTagSet = new UniqueTagList(tagSet);
-            hasChanged = true ;
-        }else{
-            newTagSet = taskToEdit.getTags();
-        }
+        newTagSet = new UniqueTagList(editOrDeleteTags(taskToEdit.getTags(), tagSet)) ;
         
         determineDateTimeOfNewTask (taskToEdit) ;
         
@@ -180,6 +175,25 @@ public class EditCommand extends Command {
                 hasChanged = true ;
             }
         }
+    }
+    
+    private Set<Tag> editOrDeleteTags(UniqueTagList currentTags, Set<Tag> tagSet) {
+        
+        Set<Tag> newTaskTags = Sets.newHashSet(currentTags) ;
+        
+        for (Tag tag : tagSet) {
+            if (!currentTags.contains(tag)) {
+                newTaskTags.add(tag) ;
+                hasChanged = true ;
+                
+            } else {
+                newTaskTags.remove(tag) ;
+                hasChanged = true ;
+            }
+            
+        }
+        
+        return newTaskTags ;
     }
 
 }


### PR DESCRIPTION
Behaviour of the improved edit command:

- If the user does not specify any tags at all; then all tags (if any) will remain unchanged.
- If the user does specify one or more tags that exists on the task object, all these tags will be deleted.
- If the user does specifiy one or more tags that does NOT exist on the task object, all these tags will be added.
- The user can add and remove tags in one edit command by specifying both tags that currently exists on the current task, and tags that does not currently exists on the current task.