### PR TITLE
CdTestCase to set data storage back to original one

### DIFF
--- a/src/test/java/guitests/CdCommandTest.java
+++ b/src/test/java/guitests/CdCommandTest.java
@@ -50,17 +50,19 @@ public class CdCommandTest extends TaskForceGuiTest {
 	public void valid_filePath() throws IOException {
 		StringBuilder sb = new StringBuilder();
 		String newPath = System.getProperty("user.dir");
-		sb.append(newPath).append("\\forTesting.xml");
+		sb.append(newPath).append("\\src\\test\\java\\guitests\\forTesting.xml");
 		System.out.println(sb.toString());
         commandBox.runCommand(("cd " + sb.toString()));
         assertResultMessage( (CdCommand.MESSAGE_SUCCESS + sb.toString()) );
         
         File file = new File("forTesting.xml");
-        System.out.println(file.delete() + " " + file.exists());
+
+        file.delete() ;
         
         File forDemoUse = new File("forDemoUse.xml");
         String forDemoUsePath = forDemoUse.getAbsolutePath();
         setUpOriginalPath(forDemoUsePath);
+ 
 	}
 	
 	@After

--- a/src/test/java/guitests/CdCommandTest.java
+++ b/src/test/java/guitests/CdCommandTest.java
@@ -1,8 +1,13 @@
 package guitests;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.Test;
 
+import seedu.address.commons.core.Config;
+import seedu.address.commons.util.ConfigUtil;
 import seedu.address.logic.commands.CdCommand;
 
 
@@ -37,20 +42,37 @@ public class CdCommandTest extends TaskForceGuiTest {
         assertResultMessage(INVALID_FILE_PATH_MESSAGE);
         commandBox.runCommand("cd asd.xml");
         assertResultMessage(INVALID_FILE_PATH_MESSAGE);
+        
+        
 	}
 	
 	@Test 
-	public void valid_filePath() {
+	public void valid_filePath() throws IOException {
 		StringBuilder sb = new StringBuilder();
 		String newPath = System.getProperty("user.dir");
-		sb.append(newPath).append("\\hey.xml");
+		sb.append(newPath).append("\\forTesting.xml");
+		System.out.println(sb.toString());
         commandBox.runCommand(("cd " + sb.toString()));
         assertResultMessage( (CdCommand.MESSAGE_SUCCESS + sb.toString()) );
+        
+        File file = new File("forTesting.xml");
+        System.out.println(file.delete() + " " + file.exists());
+        
+        File forDemoUse = new File("forDemoUse.xml");
+        String forDemoUsePath = forDemoUse.getAbsolutePath();
+        setUpOriginalPath(forDemoUsePath);
 	}
 	
 	@After
 	public void clear() {
 		commandBox.runCommand("clear");
+	}
+	
+	public void setUpOriginalPath(String path) throws IOException {
+		Config config = new Config();
+		config.setTaskForceFilePath(path);
+		ConfigUtil.saveConfig(config, "config.json");
+		
 	}
 	
 	

--- a/src/test/java/guitests/forTesting.xml
+++ b/src/test/java/guitests/forTesting.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<taskForceData/>


### PR DESCRIPTION
Changes made:
hey.xml changed name to forTesting.xml
test will save a copy of forTesting.xml in the guitests folder 
test will set back the original datastorage to forDemoUse.xml
references #102 